### PR TITLE
Initial trail points in local space

### DIFF
--- a/src/trailmesh.cpp
+++ b/src/trailmesh.cpp
@@ -109,7 +109,7 @@ void TrailMesh::_ready() {
 
 	// Initialize points.
 	for (int i = 0; i < num_points; i++) {
-		trail_points[i].center = emitter_transform.origin;
+		trail_points[i].center = to_local(emitter_transform.origin);
 		trail_points[i].direction_vector.zero();
 		trail_points[i].size = 0;
 	}


### PR DESCRIPTION
As demonstrated in #3, initializing trail points in `trailmesh.cpp` in global space causes a misplaced trail "origin". This is not really noticeable for long-lived trails, like in the demo project, but for short-lived / low point-count trails, the issue becomes visible.

This PR adjusts the point initialization from global space to local space, in order to align with local-space handling done elsewhere.
